### PR TITLE
Add full publication list directly to publications page

### DIFF
--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -32,3 +32,168 @@ author_profile: true
   {% endfor %}
 {% endif %}
 
+
+## Full Publications List
+
+Below is the publication list extracted from <http://www.commsp.ee.ic.ac.uk/~cling/publications/> with links to the referenced papers.
+
+## New
+1. [Non-Commutative Ring Learning With Errors From Cyclic Algebras](https://eprint.iacr.org/2019/680) - Charles Grover, Cong Ling, Roope Vehkalahti, submitted.
+2. [Polar Sampler: Discrete Gaussian Sampling over the Integers Using Polar Codes](https://eprint.iacr.org/2019/674) - Jiabo Wang and Cong Ling, submitted.
+3. [Lattice Reduction over Imaginary Quadratic Fields](https://arxiv.org/abs/1806.03113) - Shanxiang Lyu, Christian Porter, Cong Ling, *IEEE Trans. Signal Processing*, vol. 68, pp. 6380-6393, Nov. 2020.
+4. [Polar Lattices for Lossy Compression](http://arxiv.org/abs/1501.05683) - Ling Liu, Jinwen Shi, Cong Ling, *IEEE Trans. Inform. Theory*, to appear.
+5. [Secure Distributed Matrix Computation with Discrete Fourier Transform](https://arxiv.org/abs/2007.03972) - N. Mital, C. Ling, D. Gunduz, submitted.
+6. [Coded Caching in a Multi-Server System With Random Topology](https://arxiv.org/abs/2003.05058) - N. Mital, D. Gunduz, C. Ling, *IEEE Trans. Comm.*, vol. 68, no. 8, pp. 4620-4631, Aug. 2020.
+7. [Two quantum Ising algorithms for the Shortest Vector Problem](https://arxiv.org/abs/2006.14057) - David Joseph, Adam Callison, Cong Ling, Florian Mintert, *Physical Review A*, 103, 032433, March 2021.
+8. [Not-so-adiabatic quantum computation for the shortest vector problem](https://arxiv.org/abs/1910.10462) - David Joseph, Alexandros Ghionis, Cong Ling, Florian Mintert, *Physical Review Research*, Vol. 2, 013361, 2020.
+9. [Semantically Secure Lattice Codes for Compound MIMO Channels](https://arxiv.org/abs/1903.09954) - Antonio Campello, Cong Ling, Jean-Claude Belfiore, *IEEE Trans. Inform. Theory*, vol. 66, pp. 1572-1584, Mar 2020.
+
+## Journal Papers
+1. [Ring Compute-and-Forward over Block-Fading Channels](https://arxiv.org/abs/1805.02073) - Shanxiang Lyu, Antonio Campello, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 65, pp. 6931-6949, Nov 2019.
+2. [Lattice Gaussian Sampling by Markov Chain Monte Carlo: Bounded Distance Decoding and Trapdoor Sampling](https://arxiv.org/abs/1704.02673) - Zheng Wang, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 65, pp. 3630-3645, June 2019.
+3. Coprime Sensing via Chinese Remaindering over Quadratic Fields ([Part I](https://arxiv.org/abs/1808.07505), [Part II](https://arxiv.org/abs/1808.07511)) - Conghui Li, Lu Gan, Cong Ling, *IEEE Trans. Signal Processing*, vol. 67, pp. 2898-2910, 2911-2922, June 2019.
+4. [Polar Coding Strategies for the Interference Channel with Partial-Joint Decoding](https://arxiv.org/abs/1608.08742) - Mengfan Zheng, Cong Ling, Wen Chen, Meixia Tao, *IEEE Trans. Inform. Theory*, vol. 65, pp. 1973-1993, Apr. 2019.
+5. [AWGN-Goodness is Enough: Capacity-Achieving Lattice Codes based on Dithered Probabilistic Shaping](https://arxiv.org/abs/1707.06688) - Antonio Campello, Daniel Dadush, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 65, pp. 1961-1971, Mar. 2019.
+6. [Construction of capacity-achieving lattice codes: Polar lattices](http://arxiv.org/abs/1411.0187) - Ling Liu, Yanfei Yan, Cong Ling, Xiaofu Wu, *IEEE Trans. Commun.*, vol. 67, pp. 915-928, Feb. 2019.
+7. [Hybrid Vector Perturbation Precoding: The Blessing of Approximate Message Passing](https://arxiv.org/abs/1710.03791) - Shanxiang Lyu, Cong Ling, *IEEE Trans. Signal Processing*, vol. 67, pp. 178-193, Jan. 2019.
+8. [Universal Lattice Codes for MIMO Channels](https://arxiv.org/abs/1603.09263) - Antonio Campello, Cong Ling, Jean-Claude Belfiore, *IEEE Trans. Inform. Theory*, vol. 64, pp. 7847-7865, Dec. 2018.
+9. [Almost universal codes for MIMO wiretap channels](https://arxiv.org/abs/1611.01428) - Laura Luzzi, Roope Vehkalahti, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 64, pp. 7218-7241, Nov. 2018.
+10. [Atomic Norm Denoising-Based Joint Channel Estimation and Faulty Antenna Detection for Massive MIMO](https://arxiv.org/abs/1709.06832) - Peng Zhang, Lu Gan, Cong Ling, Sumei Sun, *IEEE Trans. Veh. Tech.*, vol. 67, pp. 1389-1403, Feb. 2018.
+11. [Polar Codes and Polar Lattices for the Heegard-Berger Problem](https://arxiv.org/abs/1702.01042) - Jinwen Shi, Ling Liu, Deniz Gündüz, Cong Ling, *IEEE Trans. Commun.*, 2018.
+12. [Polar Coding for the Cognitive Interference Channel with Confidential Messages](https://arxiv.org/abs/1710.10202) - Mengfan Zheng, Wen Chen, Cong Ling, *IEEE J. Sel. Areas Commun.*, 2018.
+13. [Secure Polar Coding for the Two-Way Wiretap Channel](https://arxiv.org/abs/1612.00130) - Mengfan Zheng, Meixia Tao, Wen Chen, Cong Ling, *IEEE Access*, vol. 6, pp. 21731-21744, Mar. 2018.
+14. [Achieving Secrecy Capacity of the Gaussian Wiretap Channel with Polar Lattices](http://arxiv.org/abs/1503.02313) - Ling Liu, Yanfei Yan, Cong Ling, Xiaofu Wu, *IEEE Trans. Inform. Theory*, vol. 64, no. 3, pp. 1647-1665, Mar. 2018.
+15. [On the Geometric Ergodicity of Metropolis-Hastings Algorithms for Lattice Gaussian Sampling](http://arxiv.org/abs/1501.05757) - Zheng Wang, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 64, no. 2, pp. 738-751, Feb. 2018.
+16. [Uniform Recovery Bounds for Structured Random Matrices in Corrupted Compressed Sensing](https://arxiv.org/abs/1706.09087) - Peng Zhang, Lu Gan, Cong Ling, Sumei Sun, *IEEE Trans. Signal Processing*, vol. 66, pp. 2086-2097, Apr. 2018.
+17. [Boosted KZ and LLL Algorithms](https://arxiv.org/abs/1703.03303) - Shanxiang Lyu, Cong Ling, *IEEE Trans. Signal Processing*, vol. 65, pp. 4784-4796, Sept. 2017.
+18. [Efficient Integer Coefficient Search for Compute-and-Forward](https://arxiv.org/abs/1609.05490) - William Liu, Cong Ling, *IEEE Trans. Wireless Commun.*, vol. 15, pp. 8039-8050, Dec. 2016.
+19. [Polar Codes and Polar Lattices for Independent Fading Channels](https://arxiv.org/abs/1601.04967) - Ling Liu, Cong Ling, *IEEE Trans. Commun.*, vol. 64, pp. 4923-4935, Dec. 2016.
+20. [Artificial-Noise-Aided Physical Layer Phase Challenge-Response Authentication for Practical OFDM Transmission](http://arxiv.org/abs/1502.07565) - Xiaofu Wu, Zhen Yan, Cong Ling, Xiang-Gen Xia, *IEEE Trans. Wireless Commun.*, vol. 15, pp. 6611-6625, Oct. 2016.
+21. [Artificial-Noise-Aided Message Authentication Codes with Information-Theoretic Security](http://arxiv.org/abs/1511.05357) - Xiaofu Wu, Zhen Yang, Cong Ling, Xiang-Gen Xia, *IEEE Trans. Inform. Forensics & Security*, vol. 11, no. 6, pp. 1278-1290, Jan. 2016.
+22. [On the Diversity of Linear Transceivers in MIMO AF Relaying Systems](http://arxiv.org/abs/1403.2081) - Changick Song, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 62, no. 1, pp. 272-289, Jan. 2016.
+23. [Modulated Unit-Norm Tight Frames for Compressed Sensing](http://arxiv.org/abs/1411.7630) - Peng Zhang, Lu Gan, Sumei Sun, Cong Ling, *IEEE Trans. Signal Processing*, vol. 63, no. 15, pp. 3974-3985, Aug. 2015.
+24. [Semantically secure lattice codes for the Gaussian wiretap channel](http://arxiv.org/abs/1210.6673) - Cong Ling, Laura Luzzi, Jean-Claude Belfiore, Damien Stehle, *IEEE Trans. Inform. Theory*, vol. 60, no. 10, pp. 6399-6416, Oct. 2014.
+25. [Achieving AWGN channel capacity with lattice Gaussian coding](http://arxiv.org/abs/1302.5906) - Cong Ling, Jean-Claude Belfiore, *IEEE Trans. Inform. Theory*, vol. 60, no. 10, pp. 5918-5929, Oct. 2014.
+26. [Decoding by sampling—Part II: Derandomization and soft-output decoding](http://arxiv.org/abs/1305.5762) - Zheng Wang, Shuiyin Liu, Cong Ling, *IEEE Trans. Commun.*, vol. 61, no. 11, pp. 4630-4639, Nov. 2013.
+27. Integration of GPS with a WiFi high accuracy ranging functionality - K. Nur, S. Fenga, C. Ling, W. Ochieng, *Geo-spatial Information Science*, vol. 16, no. 3, pp. 155-168, 2013.
+28. [Decoding by embedding: Correct decoding radius and DMT optimality](http://arxiv.org/abs/1102.2936) - Laura Luzzi, Damien Stehle, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 59, pp. 1960-1973, May 2013.
+29. [Reduced and fixed-complexity variants of the LLL algorithm for communications](http://arxiv.org/abs/1006.1661) - Cong Ling, Wai Ho Mow, Nick Howgrave-Graham, *IEEE Trans. Commun.*, vol. 61, pp. 1040-1050, Mar. 2013.
+30. [Convolutional compressed sensing using deterministic sequences](http://arxiv.org/abs/1210.7506) - Kezhi Li, Lu Gan, Cong Ling, *IEEE Trans. Signal Processing*, vol. 61, pp. 740-752, Feb. 2013.
+31. [Wyner-Ziv coding based on multi-dimensional nested lattices](http://arxiv.org/abs/1111.1347) - Cong Ling, Su Gao, Jean-Claude Belfiore, *IEEE Trans. Commun.*, vol. 60, pp.1328-1335, May 2012.
+32. [Decoding by sampling: A randomized lattice algorithm for bounded-distance decoding](http://arxiv.org/abs/1003.0064) - Shuiyin Liu, Cong Ling, Damien Stehle, *IEEE Trans. Inform. Theory*, vol. 57, pp. 5933-5945, Sept. 2011.
+33. [On the proximity factors of lattice reduction-aided decoding](http://arxiv.org/abs/1006.1666) - Cong Ling, *IEEE Trans. Signal Processing*, vol. 59, pp. 2795-2808, June 2011.
+34. Feasibility condition for interference alignment with diversity - Haishi Ning, Cong Ling, Kin K. Leung, *IEEE Trans. Inform. Theory*, vol. 57, pp. 2902-2912, May 2011.
+35. Generalized sequential slotted amplify and forward strategy in cooperative communications - Haishi Ning, Cong Ling, Kin K. Leung, *IEEE Trans. Inform. Theory*, vol. 57, pp. 1968-1974, Apr. 2011.
+36. Greedy user selection using a lattice reduction updating method for multiuser MIMO systems - L. Bai, C. Chen, J. Choi, C. Ling, *IEEE Trans. Vehicular Tech.*, vol. 60, pp. 136-147, Jan. 2011.
+37. Effect of correlated Nakagami-m fading on the e-outage channel capacity of the decentralized two-relay network - Yifan Chen, Cong Ling, *IEEE Trans. Wireless Commun.*, vol. 9, pp. 3607-3612, Dec. 2010.
+38. UWB portable printed monopole array design for MIMO communications - Daniel Valderas, Cong Ling, Pedro Crespo, *Microwave and Optical Technology Letters*, vol. 52, pp. 889-895, Apr. 2010.
+39. Dual-lattice algorithm and partial lattice reduction for SIC-based MIMO detection - Cong Ling, Wai Ho Mow, Lu Gan, *IEEE J. Sel. Topics Signal Processing*, vol. 3, pp. 975-985, Dec. 2009.
+40. New insights into weighted bit-flipping decoding - Xiaofu Wu, Cong Ling, Ming Jiang, Enyang Xu, Chunming Zhao, Xiaohu You, *IEEE Trans. Commun.*, vol. 57, pp. 2177-2180, Aug. 2009.
+41. Complex lattice reduction algorithm for low-complexity full-diversity MIMO detection - Ying Hung Gan, Cong Ling, Wai Ho Mow, *IEEE Trans. Signal Processing*, vol. 57, pp. 2701-2710, July 2009.
+42. Computation of the Para-Pseudo Inverse for Oversampled Filter Banks: Forward and Backward Greville Formulas - Lu Gan, Cong Ling, *IEEE Trans. Signal Processing*, vol. 56, pp. 5851-5860, Dec. 2008.
+43. A back-iteration method for reconstructing chaotic sequences in finite-precision machines - Cong Ling, Xiaofu Wu, *Circuits, Systems, and Signal Processing*, vol. 27, pp. 883-891, Oct. 2008.
+44. Performance of space-time codes: Gallager bounds and weight enumeration - Cong Ling, K. H. Li, A. C. Kot, *IEEE Trans. Inform. Theory*, vol. 54, pp. 3592-3610, Aug. 2008.
+45. Gallager bounds for noncoherent decoders in fading channels - Cong Ling, Xiaofu Wu, K. H. Li, A. C. Kot, *IEEE Trans. Inform. Theory*, vol. 53, pp. 4605-4614, Dec. 2007.
+46. Generalized union bound for space-time codes - Cong Ling, *IEEE Trans. Commun.*, vol. 55, pp. 90-99, Jan. 2007.
+47. New Gallager bounds in block fading channels - Xiaofu Wu, Haige Xiang, Cong Ling, *IEEE Trans. Inform. Theory*, vol. 53, pp. 684-694, Feb. 2007.
+48. Bounds on the decoding error probability of binary block codes over noncoherent block AWGN and fading channels - Xiaofu Wu, Haige Xiang, Cong Ling, Xiaohu You, Shaoqian Li, *IEEE Trans. Wireless Commun.*, vol. 5, pp. 3193-3203, Nov. 2006.
+49. Multiple-Antenna differential lattice decoding - Cong Ling, W. H. Mow, K. H. Li, A. C. Kot, *IEEE J. Sel. Areas Commun.*, vol. 23, pp. 1821-1829, Sept. 2005.
+50. On decision-feedback detection of differential space-time modulation in continuous fading - Cong Ling, K. H. Li, A. C. Kot, *IEEE Trans. Commun.*, vol. 52, pp. 1613-1617, Oct. 2004.
+51. Noncoherent sequence detection of differential space-time modulation - Cong Ling, K. H. Li, A. C. Kot, *IEEE Trans. Inform. Theory*, vol. 49, pp. 2727-2734, Oct. 2003.
+52. Multisampling decision-feedback linear prediction receivers for differential space-time modulation over Rayleigh fast fading channels - Cong Ling, K. H. Li, A. C. Kot, Q. T. Zhang, *IEEE Trans. Commun.*, vol. 51, pp. 1214-1223, July 2003.
+53. Performance evaluation for bandlimited DS-CDMA systems based on simplified improved Gaussian approximation - Guozhen Zang, Cong Ling, *IEEE Trans. Commun.*, vol. 51, pp. 1204-1213, July 2003.
+54. Family size of orthogonal Oppermann sequences - Guozhen Zang, Cong Ling, *Electronics Letters*, vol. 37, pp. 631-632, May 2001.
+55. Design and implementation of an FPGA-based generator for chaotic frequency hopping sequences - Ling Cong, Wu Xiaofu, *IEEE Trans. Circuits and Systems I*, vol. 48, pp. 521-532, May 2001.
+56. Chaotic spreading sequences with multiple access performance better than random sequences - Ling Cong, Li Shaoqian, *IEEE Trans. Circuits and Systems I*, vol. 47, pp. 394-397, Mar. 2000.
+57. On SOVA for nonbinary codes - Ling Cong, Wu Xiaofu, Yi Xiaoxin, *IEEE Commun. Lett.*, vol. 3, pp. 335-337, Dec. 1999.
+58. Data-aided phase tracking detection of frequency-shifted DPSK signals with baseband frequency-drift compensation - Xiaofu Wu, Cong Ling, Songgeng Sun, *Electronics Letters*, vol. 35, no. 15, pp. 1222-1223, July 1999.
+59. A general efficient method for chaotic signal estimation - Ling Cong, Wu Xiaofu, Sun Songgeng, *IEEE Trans. Signal Processing*, vol. 47, pp. 1424-1427, May 1999.
+60. Chaotic frequency hopping sequences - Ling Cong, Sun Songgeng, *IEEE Trans. Commun.*, vol. 46, pp. 1433-1437, Nov. 1998.
+
+## Conference Papers
+1. [Coded Computation Against Straggling Channel Decoders in the Cloud for Gaussian Channels](https://arxiv.org/abs/1805.11698) - Jinwen Shi, Cong Ling, Osvaldo Simeone, Jörg Kliewer, ISIT 2020.
+2. [Coded caching in a Multi-Server System with Random Topology](https://arxiv.org/abs/1712.00649) - Nitish Mital, Deniz Günduz, Cong Ling, WCNC 2018.
+3. [Storage-Repair Bandwidth Trade-off for Wireless Caching with Partial Failure and Broadcast Repair](https://arxiv.org/abs/1807.00220) - Nitish Mital, Katina Kralevska, Deniz Gunduz, Cong Ling, ITW 2018.
+4. [Performance Limits of Lattice Reduction over Imaginary Quadratic Fields with Applications to Compute-and-Forward](https://arxiv.org/abs/1806.03113) - Shanxiang Lyu, Christian Porter, Cong Ling, ITW 2018.
+5. Algebraic Polar Lattices for Fast Fading Channels - Ling Liu, Cong Ling, ISTC 2018.
+6. 2D MIMO Radar with Coprime Arrays - Conghui Li, Lu Gan, Cong Ling, SAM 2018.
+7. [Multilevel Code Construction for Compound Fading Channels](https://arxiv.org/abs/1701.08314) - Antonio Campello, Ling Liu, Cong Ling, ISIT 2017.
+8. [Compute-and-Forward over Block-Fading Channels Using Algebraic Lattices](https://arxiv.org/abs/1702.01422) - Shanxiang Lyu, Antonio Campello, Cong Ling, Jean-Claude Belfiore, ISIT 2017.
+9. Coprime Sensing by Chinese Remaindering over Rings - Conghui Li, Lu Gan, Cong Ling, SAMPTA 2017.
+10. Achieving Capacity and Security in Wireless Communications With Lattice Codes - Cong Ling, International Symposium on Turbo Codes 2016.
+11. Symmetric Metropolis-within-Gibbs Algorithm for Lattice Gaussian Sampling - Zheng Wang, Cong Ling, ITW 2016.
+12. Algebraic lattices achieve the capacity of the ergodic fading channel - Antonio Campello, Cong Ling, Jean-Claude Belfiore, ITW 2016.
+13. [Algebraic Lattice Codes Achieve the Capacity of the Compound Block-Fading Channel](http://arxiv.org/abs/1603.09263) - Antonio Campello, Cong Ling, Jean-Claude Belfiore, ISIT 2016.
+14. [Almost universal codes for fading wiretap channels](http://arxiv.org/abs/1601.02391) - L. Luzzi, C. Ling, R. Vehkalahti, ISIT 2016.
+15. [Polar Codes and Polar Lattices for Independent Fading Channels](http://arxiv.org/abs/1601.04967) - Ling Liu, Cong Ling, ISIT 2016.
+16. Further Results on Independent Metropolis-Hastings-Klein Sampling - Zheng Wang, Cong Ling, ISIT 2016.
+17. [Independent Metropolis-Hastings-Klein Algorithm for Lattice Gaussian Sampling](http://arxiv.org/abs/1501.05757) - Zheng Wang, Cong Ling, ISIT 2015.
+18. Atomic Norm Denoising-based Channel Estimation for Massive Multiuser MIMO Systems - Peng Zhang, Lu Gan, Sumei Sun, Cong Ling, ICC 2015.
+19. Nested Array With Time-Delayers for Target Range and Angle Estimation - Wen-Qin Wang, Cong Ling, CoSeRa 2015.
+20. [MIMO Broadcasting for Simultaneous Wireless Information and Power Transfer: Weighted MMSE Approaches](http://arxiv.org/abs/1410.4360) - Changick Song, Cong Ling, Jaehyun Park, Bruno Clerckx, Globecom 2014.
+21. Superposition Lattice Coding for Gaussian Broadcast Channel with Confidential Message - Li Chia Choo, Cong Ling, ITW 2014 (invited).
+22. [Polar Lattices for Strong Secrecy Over the Mod-Lambda Gaussian Wiretap Channel](http://arxiv.org/abs/1601.04967) - Yanfei Yan, Ling Liu, Cong Ling, ISIT 2014.
+23. Secrecy gain, flatness factor, and secrecy-goodness of even unimodular lattices - Fuchun Lin, Cong Ling, Jean-Claude Belfiore, ISIT 2014.
+24. Markov Chain Monte Carlo Algorithms for Lattice Gaussian Sampling - Zheng Wang, Cong Ling, Guillaume Hanrot, ISIT 2014.
+25. Variable-Density Sampling on the Dual Lattice - Peng Zhang, Sumei Sun, Cong Ling, ISIT 2014.
+26. Achievable Diversity-Rate Tradeoff of MIMO AF Relaying Systems with MMSE Transceivers - Changick Song, Cong Ling, ISIT 2014.
+27. Lattice Gaussian Coding for Capacity and Secrecy: Two Sides of One Coin - Cong Ling, Jean-Claude Belfiore, International Zurich Seminar on Communications 2014 (invited).
+28. Deterministic sequences for compressive MIMO channel estimation - Peng Zhang, Lu Gan, Sumei Sun, Cong Ling, EUSIPCO 2013.
+29. Lattice quantization noise revisited - Cong Ling, Lu Gan, IEEE Information Theory Workshop 2013.
+30. Barnes-Wall lattices for symmetric interference channel - Maria Estela, Cong Ling, Jean-Claude Belfiore, ISIT 2013.
+31. Polar lattices: Where Arikan meets Forney - Yanfei Yan, Cong Ling, Xiaofu Wu, ISIT 2013.
+32. Secret key generation from Gaussian sources using lattice hashing - Cong Ling, Laura Luzzi, Matthieu Bloch, ISIT 2013.
+33. Achieving the AWGN channel capacity with lattice Gaussian distribution - Cong Ling, Jean-Claude Belfiore, ISIT 2013.
+34. Reliable sub-Nyquist wideband spectrum sensing based on randomised sampling - B. Ahmad, W. Dai, C. Ling, 1st International Workshop on Compressed Sensing applied to Radar, 2012.
+35. Novel Toeplitz sensing matrices for compressive radar imaging - Lu Gan, Kezhi Li, Cong Ling, 1st International Workshop on Compressed Sensing applied to Radar, 2012.
+36. The flatness factor in lattice network coding: Design criterion and decoding algorithm - J.-C. Belfiore, Cong Ling, International Zurich Seminar on Communications 2012 (invited).
+37. A construction of lattices from polar codes - Yanfei Yan, Cong Ling, IEEE Information Theory Workshop 2012.
+38. Derandomized sampling algorithm for lattice decoding - Zheng Wang, Cong Ling, IEEE Information Theory Workshop 2012.
+39. Golay meets Hadamard: Golay-paired Hadamard matrices for fast compressed sensing - Lu Gan, Kezhi Li, Cong Ling, IEEE Information Theory Workshop 2012.
+40. Analysis of lattice codes for the many-to-one interference channel - Maria Estela, Laura Luzzi, Cong Ling, Jean-Claude Belfiore, IEEE Information Theory Workshop 2012.
+41. Lattice codes achieving strong secrecy over the mod-L Gaussian channel - C. Ling, L. Luzzi, J.-C. Belfiore, ISIT 2012.
+42. Proximity factors of lattice reduction-aided precoding for multiantenna broadcast - Shuiyin Liu, Cong Ling, Xiaofu Wu, ISIT 2012.
+43. Secrecy gain of trellis codes: The other side of the union bound - Yanfei Yan, Cong Ling, Jean-Claude Belfiore, ITW 2011, Paraty, Brazil.
+44. Decoding by embedding: Correct decoding radius and DMT optimality - Cong Ling, Shuiyin Liu, Laura Luzzi, Damien Stehle, ISIT 2011.
+45. Achievable rates for lattice coding over the Gaussian wiretap channel - Li-Chia Choo, Cong Ling, Kat-kit Wong, ICC 2011 Physical Layer Security Workshop.
+46. Deterministic compressed-sensing matrices: Where Toeplitz meets Golay - Kezhi Li, Cong Ling, Lu Gan, IEEE ICASSP 2011, Prague.
+47. Relay-aided interference alignment: Feasibility conditions and algorithm - Hashi Ning, Cong Ling, Kin K. Leung, ISIT 2010, Austin.
+48. Randomized lattice decoding: Bridging the gap between lattice reduction and sphere decoding - Shuiyin Liu, Cong Ling, Damien Stehle, ISIT 2010, Austin.
+49. A unified view of sorting in lattice reduction: From V-BLAST to LLL and beyond - Cong Ling, Wai Ho Mow, IEEE Information Theory Workshop 2009, Taormina.
+50. Statistical restricted isometry property of orthogonal symmetric Toeplitz matrices - Kezhi Li, Cong Ling, Lu Gan, IEEE Information Theory Workshop 2009, Taormina.
+51. Active physical-layer network coding for cooperative two-way relay channels - Haishi Ning, Cong Ling, Kin Leung, Second IEEE International Workshop on Wireless Network Coding, Rome, 2009.
+52. Multi-dimensional nested lattice quantization for Wyner-Ziv coding - Su Gao, Cong Ling, ICC 2009, Dresden.
+53. Near-optimal relaying strategy for cooperative broadcast channel - Haishi Ning, Cong Ling, Kin Leung, ICC 2009, Dresden.
+54. On complex LLL algorithm for digital communications - Cong Ling, Wai Ho Mow, LLL+25 Conference, Caen, 2007.
+55. Towards understanding weighted bit-flipping decoding - Xiaofu Wu, Cong Ling et al., ISIT 2007, Nice.
+56. Effective LLL reduction for lattice decoding - Cong Ling, Nick Howgrave-Graham, ISIT 2007, Nice.
+57. Computation of the dual frame: Forward and backward Greville formulas - Lu Gan, Cong Ling, IEEE ICASSP 2007.
+58. A dual-lattice view of V-BLAST detection - Cong Ling, Lu Gan, Wai Ho Mow, IEEE Information Theory Workshop 2006, Chengdu.
+59. Gallager bounds for space-time codes in quasi-static fading channels - Cong Ling, IEEE Information Theory Workshop 2006.
+60. Approximate lattice decoding: Primal versus dual basis reduction - Cong Ling, ISIT 2006, Seattle.
+61. Towards characterizing the performance of approximate lattice decoding in MIMO communications - Cong Ling, International Symposium on Turbo Codes / ITG Conference Source Channel Coding 2006, Munich.
+62. Differential lattice decoding in noncoherent MIMO communication - Cong Ling, W. H. Mow, K. H. Li, A. C. Kot, ICC 2005, Seoul.
+63. Gallager bounds for space-time codes - Cong Ling, K. H. Li, A. C. Kot, IEEE Communication Theory Workshop 2004, Capri.
+64. On Decision-Feedback Detection of Nondiagonal Differential Space-Time Modulation in Temporally Correlated Fading Channels - Cong Ling, K. H. Li, A. C. Kot, ICC 2003, Anchorage.
+65. Decision-feedback multiple symbol differential detection of differential space-time modulation in continuously fading channels - Cong Ling, K. H. Li, A. C. Kot, ICASSP 2003, Hong Kong.
+66. Linear prediction receiver for differential space-time modulation over time-correlated Rayleigh fading channels - Cong Ling, Xiaofu Wu, ICC 2002, New York.
+67. Despreading chip waveform design for coherent delay-locked tracking in DS/SS systems - Xiaofu Wu, Cong Ling, Haige Xiang, ICC 2002, New York.
+
+## Book / Book Chapter
+1. *Ultrawideband Antennas: Design and Applications* - Daniel Valderas, Juan Ignaco Sancho, David Puente, Cong Ling, Xiaodong Chen, Imperial College Press, 2010.
+2. "Network coding in heterogeneous wireless networks" - Haishi Ning, Cong Ling, in *Heterogeneous Cellular Networks*, eds. Xiaoli Chu and David Lopez Perez, Cambridge University Press, expected 2012.
+
+## Talks
+1. Workshop on interactions between number theory and wireless communication, York University, 2016.
+2. Algebraic number theory for coding and cryptography, Durham Workshop on Interactions between algebra, coding theory and cryptography, 2016.
+3. [Achieving Secrecy Capacity With Polar Codes and Polar Lattices](http://laneas.com/sites/default/files/attachments/20150923/Ling2015Achieving.pdf), Mathematical Tools of Information-Theoretic Security Workshop, Paris, 2015.
+4. Lattice Gaussian distributions: A new tool for coding and security, Oxford University, 2014.
+5. [Secrecy coding for the wiretap channel: lattices and number theory](http://www.commsp.ee.ic.ac.uk/~cling/maths.york.ac.uk/www/sites/default/files/Wiretap-York-slides.pdf), Workshop on interactions between number theory and wireless communication, York University, 2014.
+6. Lattice coding for communications and security: Two sides of one coin, Friedrich-Alexander-Universität Erlangen-Nürnberg, 2012.
+7. Bounded-distance lattice decoding and proximity factors, International Workshop on Coding and Cryptology, Qingdao, China, 2011.
+8. Lattices in communications, Lattice Algorithmics Workshop, CIRM, Marseille, France, 2010.
+9. Lattice reduction for MIMO communications: From VBLAST to LLL and beyond, University of Leeds, 2009.
+10. Gallager bounds for single and multi-antenna codes in fading channels, Hong Kong University of Science and Technology, China, 2009.
+11. On the complexity of lattice precoding for MIMO broadcast, Information Theory and Applications Workshop, University of California at San Diego, 2008.
+12. Lattice decoding for digital communications: Where Minkowski meets Shannon, ENS Lyon, 2007; Cambridge University, 2008.
+


### PR DESCRIPTION
## Summary
- remove the standalone full publications markdown page
- embed the extracted publication list directly into the main publications page

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475ab80bc0832b9b5bfe025125b820