### PR TITLE
Automate publication updates from Google Scholar

### DIFF
--- a/.github/workflows/update_scholar.yml
+++ b/.github/workflows/update_scholar.yml
@@ -1,0 +1,29 @@
+name: Update Publications from Scholar
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        pip install pyyaml scholarly
+    - name: Update publications
+      run: |
+        python scripts/update_publications_from_scholar.py
+    - name: Commit changes
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add _publications
+        git commit -m "Automated update of publications" || echo "No changes to commit"
+        git push

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ You should now be able to access the website from `localhost:4000`.
 
 If you are using [Visual Studio Code](https://code.visualstudio.com/) you can use the [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) that comes with this Repository. Normally VS Code detects that a development coontainer configuration is available and asks you if you want to use the container. If this doesn't happen you can manually start the container by **F1->DevContainer: Reopen in Container**. This restarts your VS Code in the container and automatically hosts your academic page locally on http://localhost:4000. All changes will be updated live to that page after a few seconds.
 
+## Automatic Google Scholar Updates
+
+1. Set the `site.author.googlescholar` field in `_config.yml` to your Google Scholar profile URL (e.g., `https://scholar.google.com/citations?user=XXXX`).
+2. Install the Python dependencies:
+   ```bash
+   pip install scholarly pyyaml
+   ```
+3. The workflow `Update Publications from Scholar` runs daily to pull your latest publications and commit them under `_publications/`. You can also trigger it manually from the **Actions** tab by selecting **Run workflow**.
+
+
 # Maintenance
 
 Bug reports and feature requests to the template should be [submitted via GitHub](https://github.com/academicpages/academicpages.github.io/issues/new/choose). For questions concerning how to style the template, please feel free to start a [new discussion on GitHub](https://github.com/academicpages/academicpages.github.io/discussions).

--- a/scripts/update_publications_from_scholar.py
+++ b/scripts/update_publications_from_scholar.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Update _publications from Google Scholar profile."""
+
+import os
+import re
+import yaml
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+
+try:
+    from scholarly import scholarly
+except ImportError:
+    raise SystemExit("Please install the 'scholarly' package")
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT / "_config.yml"
+PUB_DIR = ROOT / "_publications"
+
+
+def slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")
+
+
+def load_scholar_id() -> str:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(f"Config file {CONFIG_PATH} not found")
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    url = cfg.get("author", {}).get("googlescholar", "")
+    if not url:
+        return ""
+    query = urlparse(url).query
+    params = parse_qs(query)
+    return params.get("user", [""])[0]
+
+
+def publication_to_markdown(pub: dict) -> (str, str):
+    bib = pub.get("bib", {})
+    title = bib.get("title", "Untitled")
+    year = str(bib.get("pub_year", "1900"))
+    date = f"{year}-01-01"
+    slug = slugify(title)
+    permalink = f"/publication/{date}-{slug}"
+    excerpt = bib.get("abstract", "")
+    venue = bib.get("venue", "")
+    paperurl = pub.get("pub_url", "") or pub.get("eprint_url", "")
+    authors = bib.get("author", "")
+    citation = f"{authors} ({year}). \"{title}.\" {venue}."
+
+    front_matter = {
+        "title": title,
+        "collection": "publications",
+        "permalink": permalink,
+        "excerpt": excerpt,
+        "date": date,
+        "venue": venue,
+        "paperurl": paperurl,
+        "citation": citation,
+    }
+    yaml_text = yaml.safe_dump(front_matter, sort_keys=False, allow_unicode=True)
+    content = f"---\n{yaml_text}---\n"
+    filename = f"{date}-{slug}.md"
+    return filename, content
+
+
+def main():
+    scholar_id = load_scholar_id()
+    if not scholar_id:
+        raise SystemExit("No Google Scholar ID found in _config.yml")
+
+    author = scholarly.search_author_id(scholar_id)
+    author = scholarly.fill(author, sections=["publications"])
+    publications = author.get("publications", [])
+
+    PUB_DIR.mkdir(exist_ok=True)
+    for pub in publications:
+        filled = scholarly.fill(pub)
+        fname, md = publication_to_markdown(filled)
+        path = PUB_DIR / fname
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(md)
+        print(f"Updated {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fetch Google Scholar publications with new script
- run the sync daily via GitHub Actions
- document how to configure and trigger the workflow

## Testing
- `python scripts/update_publications_from_scholar.py` *(fails: No module named 'yaml')*
- `pip install pyyaml scholarly` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684786d6be2c832b8cd16331955ad9af