### PR TITLE
Automate publication updates from Google Scholar

### DIFF
--- a/.github/workflows/update_scholar.yml
+++ b/.github/workflows/update_scholar.yml
@@ -1,0 +1,26 @@
+name: Update Publications from Scholar
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Update publications
+      run: |
+        python scripts/update_publications_from_scholar.py
+    - name: Commit changes
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add _publications
+        git commit -m "Automated update of publications" || echo "No changes to commit"
+        git push

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ If you are using [Visual Studio Code](https://code.visualstudio.com/) you can us
 ## Automatic Google Scholar Updates
 
 1. Set the `site.author.googlescholar` field in `_config.yml` to your Google Scholar profile URL (e.g., `https://scholar.google.com/citations?user=XXXX`).
-2. The workflow `Update Publications from Scholar` runs daily to pull your latest publications and commit them under `_publications/`. You can also trigger it manually from the **Actions** tab by selecting **Run workflow** or run the script locally:
+2. The workflow `Update Publications from Scholar` runs daily to pull your latest publications and commit them under `_publications/`. You can also trigger it manually from the **Actions** tab or run the script locally:
    ```bash
    python scripts/update_publications_from_scholar.py
    ```
+   The script requires network access to Google Scholar and may fail behind strict firewalls.
 
 
 # Maintenance

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ You should now be able to access the website from `localhost:4000`.
 
 If you are using [Visual Studio Code](https://code.visualstudio.com/) you can use the [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) that comes with this Repository. Normally VS Code detects that a development coontainer configuration is available and asks you if you want to use the container. If this doesn't happen you can manually start the container by **F1->DevContainer: Reopen in Container**. This restarts your VS Code in the container and automatically hosts your academic page locally on http://localhost:4000. All changes will be updated live to that page after a few seconds.
 
+## Automatic Google Scholar Updates
+
+1. Set the `site.author.googlescholar` field in `_config.yml` to your Google Scholar profile URL (e.g., `https://scholar.google.com/citations?user=XXXX`).
+2. The workflow `Update Publications from Scholar` runs daily to pull your latest publications and commit them under `_publications/`. You can also trigger it manually from the **Actions** tab by selecting **Run workflow** or run the script locally:
+   ```bash
+   python scripts/update_publications_from_scholar.py
+   ```
+
+
 # Maintenance
 
 Bug reports and feature requests to the template should be [submitted via GitHub](https://github.com/academicpages/academicpages.github.io/issues/new/choose). For questions concerning how to style the template, please feel free to start a [new discussion on GitHub](https://github.com/academicpages/academicpages.github.io/discussions).

--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ author:
   # Academic websites
   academia         : # URL
   arxiv            : # URL - Update with the correct link to your profile
-  googlescholar    : "https://scholar.google.com/citations?user=PS_CX0AAAAAJ"
+  googlescholar    : "https://scholar.google.com/citations?hl=en&user=Nq5TImwAAAAJ"
   impactstory      : # URL
   orcid            : "http://orcid.org/yourorcidurl"
   semantic         : # URL

--- a/scripts/update_publications_from_scholar.py
+++ b/scripts/update_publications_from_scholar.py
@@ -9,6 +9,7 @@ public list of works using only the Python standard library.
 import re
 import html
 import urllib.request
+from urllib.error import URLError
 from pathlib import Path
 from urllib.parse import urlparse, parse_qs
 
@@ -80,8 +81,11 @@ def fetch_publications(scholar_id: str):
     """Return a list of publications for the given Scholar ID."""
     url = f"{BASE_URL}/citations?hl=en&user={scholar_id}&view_op=list_works&sortby=pubdate"
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-    with urllib.request.urlopen(req) as resp:
-        html_text = resp.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            html_text = resp.read().decode("utf-8")
+    except URLError as e:
+        raise RuntimeError(f"Failed to fetch Google Scholar page: {e}")
 
     rows = re.findall(r'<tr class="gsc_a_tr".*?</tr>', html_text, re.S)
     pubs = []

--- a/scripts/update_publications_from_scholar.py
+++ b/scripts/update_publications_from_scholar.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Update `_publications` from a Google Scholar profile.
+
+This implementation avoids third party dependencies so it can run in
+environments without network access to install packages. It scrapes the
+public list of works using only the Python standard library.
+"""
+
+import re
+import html
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT / "_config.yml"
+PUB_DIR = ROOT / "_publications"
+BASE_URL = "https://scholar.google.com"
+
+
+def slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")
+
+
+def load_scholar_id() -> str:
+    """Parse the Scholar profile URL from `_config.yml`."""
+    if not CONFIG_PATH.exists():
+        return ""
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        for line in fh:
+            if "googlescholar" in line:
+                _, val = line.split(":", 1)
+                url = val.strip().strip('"').strip("'")
+                query = urlparse(url).query
+                params = parse_qs(query)
+                return params.get("user", [""])[0]
+    return ""
+
+
+def yaml_dump(data: dict) -> str:
+    """Return a minimal YAML representation of `data`."""
+    lines = []
+    for key, value in data.items():
+        if value is None:
+            value = ""
+        escaped = str(value).replace('"', '\\"')
+        lines.append(f'{key}: "{escaped}"')
+    return "\n".join(lines)
+
+
+def publication_to_markdown(pub: dict) -> (str, str):
+    title = pub.get("title", "Untitled")
+    year = str(pub.get("year", "1900"))
+    date = f"{year}-01-01"
+    slug = slugify(title)
+    permalink = f"/publication/{date}-{slug}"
+    venue = pub.get("venue", "")
+    paperurl = pub.get("paperurl", "")
+    authors = pub.get("authors", "")
+    citation = f"{authors} ({year}). \"{title}.\" {venue}."
+
+    front_matter = {
+        "title": title,
+        "collection": "publications",
+        "permalink": permalink,
+        "date": date,
+        "venue": venue,
+        "paperurl": paperurl,
+        "citation": citation,
+    }
+    yaml_text = yaml_dump(front_matter)
+    content = f"---\n{yaml_text}\n---\n"
+    filename = f"{date}-{slug}.md"
+    return filename, content
+
+
+def fetch_publications(scholar_id: str):
+    """Return a list of publications for the given Scholar ID."""
+    url = f"{BASE_URL}/citations?hl=en&user={scholar_id}&view_op=list_works&sortby=pubdate"
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req) as resp:
+        html_text = resp.read().decode("utf-8")
+
+    rows = re.findall(r'<tr class="gsc_a_tr".*?</tr>', html_text, re.S)
+    pubs = []
+    for row in rows:
+        title_match = re.search(r'class="gsc_a_at".*?>(.*?)</a>', row)
+        title = html.unescape(title_match.group(1)) if title_match else "Untitled"
+
+        authors_match = re.findall(r'class="gs_gray">(.*?)</div>', row)
+        authors = html.unescape(authors_match[0]) if authors_match else ""
+        venue = html.unescape(authors_match[1]) if len(authors_match) > 1 else ""
+
+        year_match = re.search(r'class="gsc_a_y".*?>(\d{4})<', row)
+        year = year_match.group(1) if year_match else "1900"
+
+        link_match = re.search(r'<a class="gsc_a_at" href="(.*?)">', row)
+        paperurl = BASE_URL + link_match.group(1) if link_match else ""
+
+        pubs.append({
+            "title": title,
+            "authors": authors,
+            "venue": venue,
+            "year": year,
+            "paperurl": paperurl,
+        })
+
+    return pubs
+
+
+def main():
+    scholar_id = load_scholar_id()
+    if not scholar_id:
+        raise SystemExit("No Google Scholar ID found in _config.yml")
+
+    pubs = fetch_publications(scholar_id)
+
+    PUB_DIR.mkdir(exist_ok=True)
+    for pub in pubs:
+        fname, md = publication_to_markdown(pub)
+        path = PUB_DIR / fname
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(md)
+        print(f"Updated {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- fetch Google Scholar publications without extra packages
- run the sync daily via GitHub Actions
- document workflow trigger in README
- update Google Scholar profile link in config

## Testing
- `python scripts/update_publications_from_scholar.py` *(fails: URLError: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_684786d6be2c832b8cd16331955ad9af